### PR TITLE
fix: Treat supabase as a SupabaseClient rather than Supabasey

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>@iebh/tera-fy 2.0.17 | Documentation</title>
+  <title>@iebh/tera-fy 2.0.19 | Documentation</title>
   <meta name='description' content='TERA website worker'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>@iebh/tera-fy</h3>
-          <div class='mb1'><code>2.0.17</code></div>
+          <div class='mb1'><code>2.0.19</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/lib/syncro/entities.js
+++ b/lib/syncro/entities.js
@@ -15,12 +15,11 @@ export default {
 	projects: { // {{{
 		singular: 'project',
 		async initState({supabase, id}) {
-			let data = await supabase(s => s
+			let data = await supabase
 				.from('projects')
 				.select('data')
 				.maybeSingle()
 				.eq('id', id)
-			);
 			if (!data) throw new Error(`Syncro project "${id}" not found`);
 			data = data.data;
 
@@ -42,7 +41,7 @@ export default {
 							console.log('[MIGRATION] Creating filename:', fileName);
 
 							return Promise.resolve()
-								.then(()=> supabase(s => s // Split data.temp[toolKey] -> file {{{
+								.then(()=> supabase // Split data.temp[toolKey] -> file {{{
 									.storage
 									.from('projects')
 									.upload(
@@ -68,7 +67,7 @@ export default {
 											upsert: true,
 										},
 									)
-								)) // }}}
+								) // }}}
 								.then(()=> data.temp[toolKey] = fileName) // Replace data.temp[toolKey] with new filename
 								.catch(e => {
 									console.warn('[MIGRATION] Failed to create file', fileName, '-', e);
@@ -82,11 +81,11 @@ export default {
 			return data;
 		},
 		flushState({supabase, state, fsId}) {
-			return supabase(s => s.rpc('syncro_merge_data', {
+			return supabase.rpc('syncro_merge_data', {
 				table_name: 'projects',
 				entity_id: fsId,
 				new_data: state,
-			}))
+			})
 		},
 	}, // }}}
 	project_libraries: { // {{{
@@ -97,17 +96,20 @@ export default {
 			let fileId = relation.replace(/_\*$/, '');
 
 			return Promise.resolve()
-				.then(()=> supabase(s => s.storage
+				.then(()=> supabase.storage
 					.from('projects')
 					.list(id)
-				))
+				)
 				.then(files => files.find(f => f.id == fileId))
 				.then(file => file || Promise.reject(`Invalid file ID "${fileId}"`))
-				.then(file => supabase(s => s.storage
+				.then(file => supabase.storage
 					.from('projects')
 					.download(`${id}/${file.name}`)
-				)
-					.then(blob => ({blob, file}))
+					.then(({ data: blob, error }) => {
+						if (error) throw error;
+						if (!blob) throw new Error('Failed to download file blob');
+						return {blob, file}
+					})
 				)
 				.then(({blob, file}) => Reflib.uploadFile({
 					file: new File(
@@ -128,31 +130,37 @@ export default {
 	}, // }}}
 	project_namespaces: { // {{{
 		singular: 'project namespace',
-		initState({supabase, id, relation}) {
+		async initState({supabase, id, relation}) {
 			if (!relation) throw new Error('Project namespace relation missing, path should resemble "project_namespaces::${PROJECT}::${RELATION}"');
-			return supabase(s => s
+			let { data: rows, error: selectError } = await supabase
 				.from('project_namespaces')
 				.select('data')
-				.limit(1)
 				.eq('project', id)
 				.eq('name', relation)
-			)
-				.then(rows => rows.length == 1
-					? rows[0]
-					: supabase(s => s
-						.from('project_namespaces') // Doesn't exist - create it
-						.insert({
-							project: id,
-							name: relation,
-							data: {},
-						})
-						.select('data')
-					)
-				)
-				.then(item => item.data);
+				.limit(1);
+
+			if (selectError) throw selectError;
+
+			if (rows && rows.length == 1) {
+					return rows[0].data;
+			} else {
+				const { data: newItem, error: insertError } = await supabase
+					.from('project_namespaces') // Doesn't exist - create it
+					.insert({
+						project: id,
+						name: relation,
+						data: {},
+					})
+					.select('data')
+					.single(); // Assuming insert returns the single inserted row
+
+				if (insertError) throw insertError;
+				if (!newItem) throw new Error('Failed to create project namespace');
+				return newItem.data;
+			}
 		},
 		flushState({supabase, state, id, relation}) {
-			return supabase(s => s
+			return supabase
 				.from('project_namespaces')
 				.update({
 					edited_at: new Date(),
@@ -160,63 +168,65 @@ export default {
 				})
 				.eq('project', id)
 				.eq('name', relation)
-			)
 		},
 	}, // }}}
 	test: { // {{{
 		singular: 'test',
-		initState({supabase, id}) {
-			return supabase(s => s
+		async initState({supabase, id}) {
+			const { data: rows, error } = await supabase
 				.from('test')
 				.select('data')
-				.limit(1)
 				.eq('id', id)
-			)
-				.then(rows => rows.length == 1 ? rows[0] : Promise.reject(`Syncro test item "${id}" not found`))
-				.then(item => item.data);
+				.limit(1);
+
+			if (error) throw error;
+			if (!rows || rows.length !== 1) return Promise.reject(`Syncro test item "${id}" not found`);
+			return rows[0].data;
 		},
 		flushState({supabase, state, fsId}) {
-			return supabase(s => s.rpc('syncro_merge_data', {
+			return supabase.rpc('syncro_merge_data', {
 				table_name: 'test',
 				entity_id: fsId,
 				new_data: state,
-			}))
+			})
 		},
 	}, // }}}
 	users: { // {{{
 		singular: 'user',
-		initState({supabase, id}) {
-			return supabase(s => s
+		async initState({supabase, id}) {
+			const { data: user, error: selectError } = await supabase
 				.from('users')
 				.select('data')
-				.limit(1)
-				.maybeSingle()
 				.eq('id', id)
-			)
-				.then(user => {
-					if (user) return user.data; // User is valid and already exists
+				.maybeSingle();
 
-					// User row doesn't already exist - need to create stub
-					return supabase(s => s
-						.from('users')
-						.insert({
-							id,
-							data: {
-								id,
-								credits: 1000,
-							},
-						})
-						.select('data')
-					)
-						.then(newUser => newUser.data) // Return back the data that eventually got created - allowing for database triggers, default field values etc.
+			if (selectError) throw selectError;
+
+			if (user) return user.data; // User is valid and already exists
+
+			// User row doesn't already exist - need to create stub
+			const { data: newUser, error: insertError } = await supabase
+				.from('users')
+				.insert({
+					id,
+					data: {
+						id,
+						credits: 1000,
+					},
 				})
+				.select('data')
+				.single(); // Assuming insert returns the single inserted row
+
+			if (insertError) throw insertError;
+			if (!newUser) throw new Error('Failed to create user');
+			return newUser.data; // Return back the data that eventually got created - allowing for database triggers, default field values etc.
 		},
 		flushState({supabase, state, fsId}) {
-			return supabase(s => s.rpc('syncro_merge_data', {
+			return supabase.rpc('syncro_merge_data', {
 				table_name: 'users',
 				entity_id: fsId,
 				new_data: state,
-			}))
+			})
 		},
 	}, // }}}
 };

--- a/lib/syncro/syncro.js
+++ b/lib/syncro/syncro.js
@@ -42,9 +42,9 @@ export default class Syncro {
 
 
 	/**
-	* Supabasey wrapper function in use
+	* Supabase instance in use
 	*
-	* @type {Supabasey}
+	* @type {SupabaseClient}
 	*/
 	static supabase;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iebh/tera-fy",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iebh/tera-fy",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "license": "mit",
       "dependencies": {
         "@momsfriendlydevco/marshal": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iebh/tera-fy",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "TERA website worker",
   "scripts": {
     "dev": "esbuild --platform=browser --format=esm --bundle lib/terafy.client.js --outfile=dist/terafy.js --minify --serve --servedir=.",


### PR DESCRIPTION
Noticed that entities.js treats supabase as a Supabasey wrapper when I am 99% sure it is just a regular SupabaseClient.

initState is called from this code in `lib/syncro.keyed.js`:
```
// Go fetch the initial state object
let state = await SyncroEntities[entity].initState({
	supabase: Syncro.supabase,
	fsCollection, fsId,
	entity, id, relation,
});
```

And `Synco.supabase` is defined in `plugins.firebase.js` as:
```
import {createClient as Supabase} from '@supabase/supabase-js' // createClient() returns a SupabaseClient
...
Syncro.supabase = Supabase(settings.supabaseUrl, settings.supabaseKey); // Syncro.supabase is a SupabaseClient
```

I cannot see any other mutations of Syncro.supabase therefore I believe it is a SupabaseClient and not a Supabasey when called within entities.js (unless you can point me to where this mutation occurs).